### PR TITLE
fix: attack animations

### DIFF
--- a/AnimationManager.cs
+++ b/AnimationManager.cs
@@ -18,20 +18,23 @@ namespace CombatGame
         int rowPos;
         int colPos;
 
+        bool resetOnChange;
+
         public AnimationManager(
             int numFrames,
             int numColumns,
             Vector2 size,
             int startFrame = 0,
-            int? endFrame = null
+            int? endFrame = null,
+            bool resetOnChange = true
             )
         {
             this.numFrames = numFrames;
             this.numColumns = numColumns;
             this.size = size;
             this.startFrame = startFrame;
-            // Similarly: this.endFrame = endFrame.HasValue ? endFrame.Value : numFrames - 1;
             this.endFrame = endFrame ?? numFrames - 1;
+            this.resetOnChange = resetOnChange;
 
             counter = 0;
             interval = 18;
@@ -62,16 +65,16 @@ namespace CombatGame
                 rowPos++;
             }
 
-            var firstFrameInRow = rowPos * numColumns;
-            var lastFrameInRow = firstFrameInRow + colPos;
-            if (lastFrameInRow >= endFrame)
+            if (activeFrame >= endFrame)
                 ResetAnimation();
         }
 
-        public void ChangeFrames(int start, int end)
+        public void ChangeFrames(int start, int end, bool resetAnimation = false)
         {
             startFrame = start;
             endFrame = end;
+            if (resetAnimation)
+                ResetAnimation();
         }
 
         private void ResetAnimation()

--- a/Player.cs
+++ b/Player.cs
@@ -14,7 +14,7 @@ namespace CombatGame
         public Player(Texture2D texture, Vector2 position, AnimationManager am, List<Sprite> collisionGroup) : base(texture, position, am)
         {
             this.collisionGroup = collisionGroup;
-            this.oldState = oldState;
+            this.oldState = Keyboard.GetState();
         }
 
         public override void Update(GameTime gameTime, GraphicsDeviceManager graphics)
@@ -27,36 +27,28 @@ namespace CombatGame
 
             // Spin
             if (kState.IsKeyDown(Keys.B))
-                am.ChangeFrames(8, 12);
+                am.ChangeFrames(8, 12, true);
 
             // Kick
             if (kState.IsKeyDown(Keys.V))
-                am.ChangeFrames(12, 16);
+                am.ChangeFrames(12, 16, true);
 
             // Wand attack
             if (kState.IsKeyDown(Keys.G))
-                am.ChangeFrames(16, 20);
+                am.ChangeFrames(16, 20, true);
 
-            if (kState.IsKeyDown(Keys.Right) && oldState.IsKeyDown(Keys.Right))
-            {
-                am.ChangeFrames(4, 8);
-                changeX += SPEED;
-            }
-
-            // The player just pressed "left"
-            if (kState.IsKeyDown(Keys.Left) && !oldState.IsKeyDown(Keys.Left))
-            {
-            }
-            // The player is holding the "left" key down
-            else if (kState.IsKeyDown(Keys.Left) && oldState.IsKeyDown(Keys.Left))
+            // Walk left
+            if (kState.IsKeyDown(Keys.Left) && oldState.IsKeyDown(Keys.Left))
             {
                 am.ChangeFrames(0, 4);
                 changeX -= SPEED;
             }
-            // The player was holding the "left" key down, but has just let it go
-            else if (!kState.IsKeyDown(Keys.Left) && oldState.IsKeyDown(Keys.Left))
+
+            // Walk right
+            if (kState.IsKeyDown(Keys.Right) && oldState.IsKeyDown(Keys.Right))
             {
-                //am.ChangeFrames(0, 1);
+                am.ChangeFrames(4, 8);
+                changeX += SPEED;
             }
 
             position.X += changeX;


### PR DESCRIPTION
🐀 🐀 🐀 

- Ensure attack animations (V, B, G) reset
- Maintain continuous movement animations for arrow keys without immediate reset